### PR TITLE
Edit README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a research-oriented codebase, which has been published for the purposes of verifiability and reproducibility of the results in the paper:
 
-* Otto Seiskari, Pekka Rantalankila, Juho Kannala, Jerry Ylilammi, Esa Rahtu, and Arno Solin (2022). **HybVIO: Pushing the limits of real-time visual-inertial odometry**. In *IEEE Winter Conference on Applications of Computer Vision (WACV)*.  
+* Otto Seiskari, Pekka Rantalankila, Juho Kannala, Jerry Ylilammi, Esa Rahtu, and Arno Solin (2022). **HybVIO: Pushing the limits of real-time visual-inertial odometry**. In *IEEE Winter Conference on Applications of Computer Vision (WACV)*.
 [[arXiv pre-print]](https://arxiv.org/abs/2106.11857) | [[video]](https://youtu.be/8V_EGJrPHeA)
 
 It can also serve as a baseline in VIO and VISLAM benchmarks. The code is not intended for production use and does not represent a particularly clean or simple way of implementing the methods described in the above paper. The code contains numerous feature flags and parameters (see `codegen/parameter_definitions.c`) that are not used in the HybVIO but may (or may not) be relevant in other scenarios and use cases.
@@ -21,7 +21,7 @@ Here are basic instructions for setting up the project, there is some more detai
 * Make sure you are using `clang` to compile the C++ sources (it's the default on Macs).
   If not default, like on many Linux Distros, you can control this with environment variables,
   e.g., `CC=clang CXX=clang++ ./scripts/build.sh`
-* (optional) In order to be able to use the SLAM module, run `./slam/src/download_orb_vocab.sh`
+* (optional) In order to be able to use the SLAM module, run `./src/slam/download_orb_vocab.sh`
 
 Then, to build the main and test binaries, perform the standard CMake routine:
 
@@ -31,7 +31,7 @@ cd target
 cmake -DBUILD_VISUALIZATIONS=ON -DUSE_SLAM=ON ..
 # or if not using clang by default:
 # CC=clang CXX=clang++ cmake ..
-make
+make -j6
 ```
 
 Now the `target` folder should contain the binaries `main` and `run-tests`. After making changes to code, only run `make`. Tests can be run with the binary `run-tests`.
@@ -40,7 +40,7 @@ To compile faster, pass `-j` argument to `make`, or use a program like `ccache`.
 
 ### Arch Linux
 
-List of packages needed: blas, cblas, clang, cmake, ffmpeg, glfw, gtk3, lapack, python-numpy, python-matplotlib.
+List of packages needed: clang, cmake, ffmpeg, glfw, gtk3
 
 ### Debian
 
@@ -50,30 +50,20 @@ On Debian Stretch, had to install (some might be optional): clang, libc++-dev, l
 
 On Raspbian (Pi 4, 8 GiB), had to install at least: libglfw3-dev and libglfw3 (for accelerated arrays) and libglew-dev and libxkbcommon-dev (for Pangolin, still had problems). Also started off with the Debian setup above.
 
-## Benchmarking
+## Benchmarking and the `main` binary
 
-### EuroC
+To run benchmarks on EuRoC, TUM and SenseTime datasets and reproduce numbers published in https://arxiv.org/abs/2106.11857, please follow the instructions in https://github.com/AaltoML/vio_benchmark/tree/main/hybvio_runner.
 
-To run benchmarks on EuroC dataset and reproduce numbers published in https://arxiv.org/abs/2106.11857, follow the instructions in https://github.com/AaltoML/vio_benchmark/tree/main/hybvio_runner.
+If you want to test the software on individual datasets, e.g. to see various real-time visualizations, you can use the `main` binary. For example to run an EuRoC dataset, you can do the following:
 
-If you want to test the software on individual EuRoC datasets, you can follow this subset of instructions
-
- 1. In [`vio_benchmark`](https://github.com/AaltoML/vio_benchmark) root folder, run `python convert/euroc_to_benchmark.py` to download and convert to data
+ 1. In [`vio_benchmark`](https://github.com/AaltoML/vio_benchmark) root folder, run `python convert/euroc_to_benchmark.py` to download and convert the EuRoC data
  2. Symlink that data here: `mkdir -p data && cd data && ln -s /path/to/vio_benchmark/data/benchmark .`
 
-Then you can run inividual EuRoC sequences as, e.g.,
+Then inside the `target/` folder use, e.g.:
 
     ./main -i=../data/benchmark/euroc-v1-02-medium -p -useStereo
 
-### ADVIO
-
- 1. Download the ADVIO dataset as instructed in https://github.com/AaltoVision/ADVIO#downloading-the-data and extract all the `.zip` files somewhere ("`/path/to/advio`").
- 2. Run `./scripts/convert/advio_to_generic_benchmark.sh /path/to/advio`
- 3. Then you can run ADVIO sequences either using their full path (like in EuRoC) or using the `-j` shorthand, e.g., `./main -j=2` for ADVIO-02.
-
-## The `main` binary
-
-To run the algorithm on recorded data, use `./main -i=path/to/datafolder`, where `datafolder/` must at the very least contain a `data.{jsonl|csv}` and `data.{mp4|mov|avi}`. Such recordings can be created with
+In general, to run the algorithm on recorded data, use `./main -i=path/to/datafolder`, where `datafolder/` must at the very least contain a `data.{jsonl|csv}` and `data.{mp4|mov|avi}`. Such recordings can be created with
 
  * [Android VIO tester](https://github.com/AaltoML/android-viotester)
  * [realsense-capture](https://github.com/AaltoVision/realsense-capture)
@@ -92,7 +82,7 @@ Some common arguments to `main` are:
 
 You can get full list of command line options with `./main -help`.
 
-### Key controls
+### Key controls for `main`
 
 These keys can be used when any of the graphical windows are focused (see `commandline/command_queue.cpp` for full list).
 


### PR DESCRIPTION
I tested all the steps and edited the text, mainly with the aim to make this README focus on usage of the `main` binary, while the paper result reproduction steps are (will be) in the `vio_benchmark` repository `hybvio_runner` folder README.