### PR TITLE
Add CITATION.bib

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,8 @@
+@InProceedings{Seiskari_2022_WACV,
+    author    = {Seiskari, Otto and Rantalankila, Pekka and Kannala, Juho and Ylilammi, Jerry and Rahtu, Esa and Solin, Arno},
+    title     = {{HybVIO}: Pushing the Limits of Real-Time Visual-Inertial Odometry},
+    booktitle = {Proceedings of the IEEE/CVF Winter Conference on Applications of Computer Vision (WACV)},
+    month     = {January},
+    year      = {2022},
+    pages     = {701-710}
+}


### PR DESCRIPTION
This will add a button in the repository main page that links to the file, see it [here](https://github.com/SpectacularAI/HybVIO/tree/citation-bib). There is some more general format with `cff` extension that allows exporting to BibTeX and other formats (currently just APA), but we don't have our citation ready in that format.